### PR TITLE
Change `ON` to `IN` for `GRANT` syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDEs
+.idea/
+
 exp/
 export/
 EXP/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+numpy

--- a/sfprovisionconfig.py
+++ b/sfprovisionconfig.py
@@ -386,8 +386,8 @@ class SfProvisionConfig():
                         if sing_obj not in seen.keys():
                             self.grant_create_privilege(sing_obj, f"ON SCHEMA {cmdline.db_nm}.{cmdline.sc_nm}", ar_role)
                             seen[sing_obj] = 1
-                    self.grant_privilege_in(privilege, f"ALL {object}", f"{cmdline.db_nm}.{cmdline.sc_nm}", 'ON SCHEMA', ar_role)
-                    self.grant_future_privilege_in(privilege, object, f"{cmdline.db_nm}.{cmdline.sc_nm}", 'ON SCHEMA', ar_role)
+                    self.grant_privilege_in(privilege, f"ALL {object}", f"{cmdline.db_nm}.{cmdline.sc_nm}", 'IN SCHEMA', ar_role)
+                    self.grant_future_privilege_in(privilege, object, f"{cmdline.db_nm}.{cmdline.sc_nm}", 'IN SCHEMA', ar_role)
         
     def create_sc_r2r_grants(self):
         cfg = self.sc

--- a/sfprovisionconfig.py
+++ b/sfprovisionconfig.py
@@ -514,12 +514,19 @@ class SfProvisionConfig():
             print(grants)
 
     def print_drop(self):
-        for grant_revokes in self.revoke_obj_grants[::-1]:
-            print(grant_revokes)
-        print()
-        for role_revoke in self.revoke_role_grants[::-1]:
-            print(role_revoke)
-        print()
+        # For now, when drop object is used, the revoke is superfluous (wastes credits)
+        # It also generates some errors if something was already removed.
+        # Ideally this should be configured somewhere but setting a boolean here for now
+        revoke_obj_grants = False
+        revoke_role_grants = False
+        if revoke_obj_grants:
+            for grant_revokes in self.revoke_obj_grants[::-1]:
+                print(grant_revokes)
+            print()
+        if revoke_role_grants:
+            for role_revoke in self.revoke_role_grants[::-1]:
+                print(role_revoke)
+            print()
         for drops in self.drop_objects[::-1]:
             print(drops)
         


### PR DESCRIPTION
## GRANT Syntax change/clash

when running:
```
./sf_create_obj schema <DB>.<SCHEMA>
```
I got `GRANT` statements which didn't work, so I've changed the logic around. I can see that it was changed over in a previous change: 
- https://github.com/thomaseibner/snowflake-provisioning/commit/5d73b57683303e6dc99670b7090b6d21b15c4a32
- https://github.com/d-roman-halliday/snowflake-provisioning/commit/5d73b57683303e6dc99670b7090b6d21b15c4a32 

I'm not sure if this is a case of the previous change being a bug (it was changed in other places too then), or if we have a clash (in some cases we want it to be `ON` in this statement and in others we want `IN`).

### Changes:
1. Adding standard python `.gitignore`
2. Adding `requirements.txt` for `sf_create_obj` functionality
3. Change `ON` to `IN` for `GRANT` syntax (for `./sf_create_obj schema <DB>.<SCHEMA>`)